### PR TITLE
(chore): clean up naming and styles

### DIFF
--- a/content.py
+++ b/content.py
@@ -108,7 +108,7 @@ benefits = [
 
 faqs = [
     ("What kinds of applications can be written with this?",
-     "It's good for: general purpose web applications (i.e anything you'd build with React, Django, NexJS, etc); quick dashboards, prototypes, and in-company apps (e.g. like what you might use gradio/streamlit/etc for); Analytics/models/dashboards interactive reports; Custom blogs and content-heavy sites where you also want some interactive/dynamic content."),
+     "It's good for: general purpose web applications (i.e anything you'd build with React, Django, Next.js, etc); quick dashboards, prototypes, and in-company apps (e.g. like what you might use gradio/streamlit/etc for); Analytics/models/dashboards interactive reports; Custom blogs and content-heavy sites where you also want some interactive/dynamic content."),
     ("Where can I deploy my FastHTML to? What's needed?",
      "You can deploy a FastHTML app to any service or server that supports Python. We have guides and helpers for Railway.app, Vercel, Hugging Face Spaces, Replit, and PythonAnywhere. You can also use any VPS or server, or any on-premise machine with Python installed. All major operating systems are supported."),
     ("How does FastHTML relate to FastAPI?",
@@ -119,7 +119,7 @@ faqs = [
      "HTMX is best thought of as filling in the missing bits of a web browser -- in fact, web browser manufacturers are considering incorporating similar features directly into future browsers. It is a small javascript library that with a single line of HTML lets you respond to any event from any part of a web page by modifying the DOM in any way you like, all directly from Python. Whilst you don't have to use it with FastHTML, it will dramatically increase the amount of stuff you can do!"),
     ("Do I need to know JS? Can I use it if I want, with FastHTML?",
      "No, and yes! You can write nearly any standard web app with just Python. However, using a bit of JS can be helpful -- for instance, nearly any existing JS lib can be incorporated into a FastHTML app, and you can sprinkle bits of JS into your pages anywhere you like."),
-    ("Are FastHTML apps slower than React, Next.JS, etc?",
+    ("Are FastHTML apps slower than React, Next.js, etc?",
      "It depends. Apps using FastHTML and HTMX are often faster than JS-based approaches using big libraries, since they can be very lightweight.")
 ]
 

--- a/index.html
+++ b/index.html
@@ -1415,7 +1415,7 @@
                 class="overflow-hidden max-h-0 pl-6 lg:pl-8 pr-4 lg:pr-6 peer-checked/collapsible:max-h-[30rem] peer-checked/collapsible:pb-4 peer-checked/collapsible:lg:pb-6 peer-checked/collapsible:transition-all duration-300 ease-in-out s-body text-black/80 col-span-full"
               >
                 It's good for: general purpose web applications (i.e anything
-                you'd build with React, Django, NexJS, etc); quick dashboards,
+                you'd build with React, Django, Next.js, etc); quick dashboards,
                 prototypes, and in-company apps (e.g. like what you might use
                 gradio/streamlit/etc for); Analytics/models/dashboards
                 interactive reports; Custom blogs and content-heavy sites where
@@ -1625,7 +1625,7 @@
                 class="flex justify-between items-center cursor-pointer py-4 lg:py-6 pl-6 lg:pl-8 pr-4 lg:pr-6"
               >
                 <p class="text-black s-body flex-grow">
-                  Are FastHTML apps slower than React, Next.JS, etc?
+                  Are FastHTML apps slower than React, Next.js, etc?
                 </p>
                 <img
                   src="./assets/icons/plus-icon.svg"

--- a/main.py
+++ b/main.py
@@ -69,7 +69,7 @@ def code_display(file_name, code_snippet, snippet_id):
     )
 
 def code_demo(title, file_name, code_snippet, demo_content, is_active=False):
-    demo_cls = f"{center} my-11 p-4 flex-none whitespace-normal justify-center h-96 rounded-3xl bg-soft-purple lg:p-8 w-full max-w-2xl lg:max-w-md lg:mx-28 lg:my-8"
+    demo_cls = f"{center} my-11 p-4 flex-none whitespace-normal justify-center h-96 rounded-3xl overflow-y-auto bg-soft-purple lg:p-8 w-full max-w-2xl lg:max-w-md lg:mx-28 lg:my-8"
     snippet_id = f"{title.lower().replace(' ', '-')}-code-snippet"
     return Div(
         code_display(file_name, code_snippet, snippet_id),


### PR DESCRIPTION
This PR:

- [x] Ensures Next.js is written as they do on their website
- [x] Fixes overflow styles on the home page

![CleanShot 2024-07-31 at 18 58 40](https://github.com/user-attachments/assets/e7931dba-eb70-4cdc-b41a-d28ff49391de)

It doesn't seem like there's an automated way to generate the `index.html` so I just made the changes there.